### PR TITLE
Add feature gates and configurations

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,4 +22,4 @@ jobs:
     - name: Run linters
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.50.0
+        version: v1.53.3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.4
+        go-version: ">=1.20"
     - name: Run linters
       uses: golangci/golangci-lint-action@v3
       with:

--- a/internal/v1/authorization/authorization.go
+++ b/internal/v1/authorization/authorization.go
@@ -1,0 +1,20 @@
+package authorization
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/adh-partnership/api/pkg/auth"
+	"github.com/adh-partnership/api/pkg/gin/response"
+)
+
+// Get Authorization Grouos
+// @Summary Get Authorization Groups
+// @Description Get Authorization Groups
+// @Tags Auth
+// @Success 200 {object} map[string][]string
+// @Router /v1/authorization/groups [get]
+func getGroups(c *gin.Context) {
+	response.Respond(c, http.StatusOK, auth.Groups)
+}

--- a/internal/v1/authorization/main.go
+++ b/internal/v1/authorization/main.go
@@ -1,0 +1,9 @@
+package authorization
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func Routes(r *gin.RouterGroup) {
+	r.GET("", getGroups)
+}

--- a/internal/v1/router/router.go
+++ b/internal/v1/router/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/adh-partnership/api/internal/v1/admin"
 	"github.com/adh-partnership/api/internal/v1/airport"
+	"github.com/adh-partnership/api/internal/v1/authorization"
 	"github.com/adh-partnership/api/internal/v1/email"
 	"github.com/adh-partnership/api/internal/v1/event"
 	"github.com/adh-partnership/api/internal/v1/feedback"
@@ -16,6 +17,7 @@ import (
 	"github.com/adh-partnership/api/internal/v1/training"
 	"github.com/adh-partnership/api/internal/v1/user"
 	"github.com/adh-partnership/api/internal/v1/weather"
+	"github.com/adh-partnership/api/pkg/config"
 	"github.com/adh-partnership/api/pkg/logger"
 )
 
@@ -27,10 +29,13 @@ func init() {
 	routeGroups = make(map[string]func(*gin.RouterGroup))
 	routeGroups["/admin"] = admin.Routes
 	routeGroups["/airports"] = airport.Routes
+	routeGroups["/authorization"] = authorization.Routes
 	routeGroups["/email"] = email.Routes
 	routeGroups["/events"] = event.Routes
 	routeGroups["/feedback"] = feedback.Routes
-	routeGroups["/staffing"] = staffing.Routes
+	if config.Cfg.Features.StaffingRequest {
+		routeGroups["/staffing"] = staffing.Routes
+	}
 	routeGroups["/overflight"] = overflight.Routes
 	routeGroups["/proxy"] = proxy.Routes
 	routeGroups["/stats"] = stats.Routes

--- a/internal/v1/staffing/main.go
+++ b/internal/v1/staffing/main.go
@@ -1,17 +1,9 @@
 package staffing
 
 import (
-	"fmt"
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 
-	"github.com/adh-partnership/api/pkg/database/dto"
-	"github.com/adh-partnership/api/pkg/database/models"
-	"github.com/adh-partnership/api/pkg/discord"
 	"github.com/adh-partnership/api/pkg/gin/middleware/auth"
-	"github.com/adh-partnership/api/pkg/gin/response"
 	"github.com/adh-partnership/api/pkg/logger"
 )
 
@@ -19,41 +11,4 @@ var log = logger.Logger.WithField("component", "staffing")
 
 func Routes(r *gin.RouterGroup) {
 	r.POST("", auth.NotGuest, requestStaffing)
-}
-
-// Submit a staffing request.
-// @Summary Submit a staffing request
-// @Description Submit a staffing request
-// @Tags Staffing
-// @Param data body dto.StaffingRequest true "Request Data"
-// @Success 204
-// @Failure 400 {object} response.R "Invalid form submission"
-// @Failure 401 {object} response.R "Not logged in"
-// @Failure 500 {object} response.R
-// @Router /v1/staffing/ [post]
-func requestStaffing(c *gin.Context) {
-	user := c.MustGet("x-user").(*models.User)
-
-	var dto dto.StaffingRequest
-	if err := c.ShouldBind(&dto); err != nil {
-		log.Debugf("Error binding dto: %s", err)
-		response.RespondError(c, http.StatusBadRequest, "Invalid request")
-		return
-	}
-
-	err := discord.NewMessage().
-		SetContent("New staffing request").
-		AddEmbed(discord.NewEmbed().
-			AddField(discord.NewField().SetName("Requester").SetValue(fmt.Sprintf("%s %s (%d)", user.FirstName, user.LastName, user.CID))).
-			AddField(discord.NewField().SetName("Date").SetValue(dto.Date)).
-			AddField(discord.NewField().SetName("DepartureAirport").SetValue(dto.DepartureAirport)).
-			AddField(discord.NewField().SetName("ArrivalAirport").SetValue(dto.ArrivalAirport)).
-			AddField(discord.NewField().SetName("Pilots").SetValue(strconv.Itoa(dto.Pilots))).
-			AddField(discord.NewField().SetName("Comments").SetValue(dto.Comments)),
-		).Send("staffing_request")
-	if err != nil {
-		log.Errorf("Error sending staffing request message to Discord: %s", err.Error())
-	}
-
-	response.RespondBlank(c, http.StatusNoContent)
 }

--- a/internal/v1/staffing/staffing.go
+++ b/internal/v1/staffing/staffing.go
@@ -1,0 +1,51 @@
+package staffing
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/adh-partnership/api/pkg/database/dto"
+	"github.com/adh-partnership/api/pkg/database/models"
+	"github.com/adh-partnership/api/pkg/discord"
+	"github.com/adh-partnership/api/pkg/gin/response"
+)
+
+// Submit a staffing request.
+// @Summary Submit a staffing request
+// @Description Submit a staffing request
+// @Tags Staffing
+// @Param data body dto.StaffingRequest true "Request Data"
+// @Success 204
+// @Failure 400 {object} response.R "Invalid form submission"
+// @Failure 401 {object} response.R "Not logged in"
+// @Failure 500 {object} response.R
+// @Router /v1/staffing/ [post]
+func requestStaffing(c *gin.Context) {
+	user := c.MustGet("x-user").(*models.User)
+
+	var dto dto.StaffingRequest
+	if err := c.ShouldBind(&dto); err != nil {
+		log.Debugf("Error binding dto: %s", err)
+		response.RespondError(c, http.StatusBadRequest, "Invalid request")
+		return
+	}
+
+	err := discord.NewMessage().
+		SetContent("New staffing request").
+		AddEmbed(discord.NewEmbed().
+			AddField(discord.NewField().SetName("Requester").SetValue(fmt.Sprintf("%s %s (%d)", user.FirstName, user.LastName, user.CID))).
+			AddField(discord.NewField().SetName("Date").SetValue(dto.Date)).
+			AddField(discord.NewField().SetName("DepartureAirport").SetValue(dto.DepartureAirport)).
+			AddField(discord.NewField().SetName("ArrivalAirport").SetValue(dto.ArrivalAirport)).
+			AddField(discord.NewField().SetName("Pilots").SetValue(strconv.Itoa(dto.Pilots))).
+			AddField(discord.NewField().SetName("Comments").SetValue(dto.Comments)),
+		).Send("staffing_request")
+	if err != nil {
+		log.Errorf("Error sending staffing request message to Discord: %s", err.Error())
+	}
+
+	response.RespondBlank(c, http.StatusNoContent)
+}

--- a/pkg/auth/roles.go
+++ b/pkg/auth/roles.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"dario.cat/mergo"
+
 	"github.com/adh-partnership/api/pkg/database/models"
 	"github.com/adh-partnership/api/pkg/logger"
 )
@@ -139,38 +141,6 @@ var Roles = map[string]Role{
 			"wm",
 		},
 	},
-	"k8s-cluster-admin": {
-		Name: "k8s-cluster-admin",
-		RolesCanAdd: []string{
-			"atm",
-			"datm",
-			"wm",
-		},
-	},
-	"k8s-cluster-webteam": {
-		Name: "k8s-cluster-webteam",
-		RolesCanAdd: []string{
-			"atm",
-			"datm",
-			"wm",
-		},
-	},
-	"k8s-cluster-mysql": {
-		Name: "k8s-cluster-mysql",
-		RolesCanAdd: []string{
-			"atm",
-			"datm",
-			"wm",
-		},
-	},
-	"k8s-cluster-mysql-write": {
-		Name: "k8s-cluster-mysql-write",
-		RolesCanAdd: []string{
-			"atm",
-			"datm",
-			"wm",
-		},
-	},
 }
 
 func CanUserModifyRole(user *models.User, role string) bool {
@@ -215,4 +185,10 @@ func HasRole(user *models.User, role string) bool {
 		}
 	}
 	return false
+}
+
+func SetupGroups(groups map[string][]string) {
+	if err := mergo.Merge(&Groups, groups, mergo.WithOverride); err != nil {
+		log.Fatalf("Error merging groups: %v", err)
+	}
 }

--- a/pkg/config/configtypes.go
+++ b/pkg/config/configtypes.go
@@ -1,16 +1,18 @@
 package config
 
 type Config struct {
-	Server   ConfigServer   `json:"server"`
-	Database ConfigDatabase `json:"database"`
-	Discord  ConfigDiscord  `json:"discord"`
-	Email    ConfigEmail    `json:"email"`
-	Facility ConfigFacility `json:"facility"`
-	Metrics  ConfigMetrics  `json:"metrics"`
-	OAuth    ConfigOAuth    `json:"oauth"`
-	Session  ConfigSession  `json:"session"`
-	Storage  ConfigStorage  `json:"storage"`
-	VATUSA   ConfigVATUSA   `json:"vatusa"`
+	Database ConfigDatabase      `json:"database"`
+	Discord  ConfigDiscord       `json:"discord"`
+	Email    ConfigEmail         `json:"email"`
+	Facility ConfigFacility      `json:"facility"`
+	Features ConfigFeatures      `json:"features"`
+	Groups   map[string][]string `json:"groups"`
+	Metrics  ConfigMetrics       `json:"metrics"`
+	OAuth    ConfigOAuth         `json:"oauth"`
+	Server   ConfigServer        `json:"server"`
+	Session  ConfigSession       `json:"session"`
+	Storage  ConfigStorage       `json:"storage"`
+	VATUSA   ConfigVATUSA        `json:"vatusa"`
 }
 
 type ConfigServer struct {
@@ -41,6 +43,10 @@ type ConfigEmail struct {
 	Password    string `json:"password"`
 	From        string `json:"from"`
 	TemplateDir string `json:"template_dir"`
+}
+
+type ConfigFeatures struct {
+	StaffingRequest bool `json:"staffing_request"`
 }
 
 type ConfigSession struct {


### PR DESCRIPTION
- Staffing request exposes a Discord webhook nearly publicly... this could be bad. Pref for ZAN is to use email allowing us to respond to staffing requests as well as keeping webhooks from being easily publicly triggerable.
- Moved group configuration to configuration. The old configuration is default, with overrides possible via config. This allows facilities to decide who they want to edit things
- Added /authorization/groups endpoint which will share the group authorizations, allowing the frontend to pull and use this instead of duplicating group configurations

Closes #148 