### PR TITLE
Add new config flag to control Discord msgs for

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -57,6 +57,8 @@ facility:
     - PUB
     - RAP
     - RCA
+  training_requests:
+    enabled: false
 session:
   cookie:
     name: "zdv_session"

--- a/internal/v1/training/requests.go
+++ b/internal/v1/training/requests.go
@@ -218,7 +218,9 @@ func patchTrainingRequest(c *gin.Context) {
 		}
 
 		if request.Status != "" && request.Status != req.Status {
-			if request.Status == constants.TrainingSessionStatusAccepted && req.Status == constants.TrainingSessionStatusOpen && config.Cfg.Facility.TrainingRequests.SendToDiscord {
+			if request.Status == constants.TrainingSessionStatusAccepted &&
+				req.Status == constants.TrainingSessionStatusOpen &&
+				config.Cfg.Facility.TrainingRequests.SendToDiscord {
 				go func(r *models.TrainingRequest) {
 					u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
 					_ = discord.NewMessage().

--- a/internal/v1/training/requests.go
+++ b/internal/v1/training/requests.go
@@ -132,25 +132,27 @@ func postTrainingRequest(c *gin.Context) {
 		}
 	}
 
-	go func(r *models.TrainingRequest) {
-		u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
-		_ = discord.NewMessage().
-			SetContent("New Training Request has been submitted").
-			AddEmbed(
-				discord.NewEmbed().
-					AddField(
-						discord.NewField().SetName("Controller").SetValue(
-							fmt.Sprintf("%s %s (%d/%s)", r.Student.FirstName, r.Student.LastName, r.Student.CID, u.Rating.Short),
-						).SetInline(false),
-					).
-					AddField(
-						discord.NewField().SetName("Position").SetValue(r.Position).SetInline(true),
-					).
-					AddField(
-						discord.NewField().SetName("Notes").SetValue(r.Notes).SetInline(false),
-					).SetURL(fmt.Sprintf("%s/training/sessions/%s", config.Cfg.Facility.FrontendURL, r.ID)),
-			).Send(config.Cfg.Facility.TrainingRequests.Discord.Scheduled)
-	}(req)
+	if config.Cfg.Facility.TrainingRequests.SendToDiscord {
+		go func(r *models.TrainingRequest) {
+			u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
+			_ = discord.NewMessage().
+				SetContent("New Training Request has been submitted").
+				AddEmbed(
+					discord.NewEmbed().
+						AddField(
+							discord.NewField().SetName("Controller").SetValue(
+								fmt.Sprintf("%s %s (%d/%s)", r.Student.FirstName, r.Student.LastName, r.Student.CID, u.Rating.Short),
+							).SetInline(false),
+						).
+						AddField(
+							discord.NewField().SetName("Position").SetValue(r.Position).SetInline(true),
+						).
+						AddField(
+							discord.NewField().SetName("Notes").SetValue(r.Notes).SetInline(false),
+						).SetURL(fmt.Sprintf("%s/training/sessions/%s", config.Cfg.Facility.FrontendURL, r.ID)),
+				).Send(config.Cfg.Facility.TrainingRequests.Discord.Scheduled)
+		}(req)
+	}
 
 	response.Respond(c, http.StatusCreated, dto.ConvertTrainingRequestToDTO(req))
 }
@@ -216,7 +218,7 @@ func patchTrainingRequest(c *gin.Context) {
 		}
 
 		if request.Status != "" && request.Status != req.Status {
-			if request.Status == constants.TrainingSessionStatusAccepted && req.Status == constants.TrainingSessionStatusOpen {
+			if request.Status == constants.TrainingSessionStatusAccepted && req.Status == constants.TrainingSessionStatusOpen && config.Cfg.Facility.TrainingRequests.SendToDiscord {
 				go func(r *models.TrainingRequest) {
 					u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
 					_ = discord.NewMessage().
@@ -250,29 +252,31 @@ func patchTrainingRequest(c *gin.Context) {
 		if request.Status == constants.TrainingSessionStatusCancelled && req.Status == constants.TrainingSessionStatusAccepted {
 			req.Start = nil
 			req.End = nil
-			go func(r *models.TrainingRequest) {
-				u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
-				_ = discord.NewMessage().
-					SetContent("Scheduled Training Session set to Cancelled").
-					AddEmbed(
-						discord.NewEmbed().
-							SetColor(discord.GetColor("ff", "00", "00")).
-							AddField(
-								discord.NewField().SetName("Controller").SetValue(
-									fmt.Sprintf("%s %s (%d/%s)", r.Student.FirstName, r.Student.LastName, r.Student.CID, u.Rating.Short),
-								).SetInline(false),
-							).
-							AddField(
-								discord.NewField().SetName("Position").SetValue(r.Position).SetInline(true),
-							).
-							AddField(
-								discord.NewField().SetName("Scheduled At").SetValue(r.Start.Format(time.RFC1123)).SetInline(false),
-							).
-							AddField(
-								discord.NewField().SetName("Notes").SetValue(r.Notes).SetInline(false),
-							).SetURL(fmt.Sprintf("%s/training/sessions/%s", config.Cfg.Facility.FrontendURL, r.ID)),
-					).Send(config.Cfg.Facility.TrainingRequests.Discord.TrainingStaff)
-			}(req)
+			if config.Cfg.Facility.TrainingRequests.SendToDiscord {
+				go func(r *models.TrainingRequest) {
+					u, _ := database.FindUserByCID(fmt.Sprint(r.Student.CID))
+					_ = discord.NewMessage().
+						SetContent("Scheduled Training Session set to Cancelled").
+						AddEmbed(
+							discord.NewEmbed().
+								SetColor(discord.GetColor("ff", "00", "00")).
+								AddField(
+									discord.NewField().SetName("Controller").SetValue(
+										fmt.Sprintf("%s %s (%d/%s)", r.Student.FirstName, r.Student.LastName, r.Student.CID, u.Rating.Short),
+									).SetInline(false),
+								).
+								AddField(
+									discord.NewField().SetName("Position").SetValue(r.Position).SetInline(true),
+								).
+								AddField(
+									discord.NewField().SetName("Scheduled At").SetValue(r.Start.Format(time.RFC1123)).SetInline(false),
+								).
+								AddField(
+									discord.NewField().SetName("Notes").SetValue(r.Notes).SetInline(false),
+								).SetURL(fmt.Sprintf("%s/training/sessions/%s", config.Cfg.Facility.FrontendURL, r.ID)),
+						).Send(config.Cfg.Facility.TrainingRequests.Discord.TrainingStaff)
+				}(req)
+			}
 		}
 
 		req.Status = request.Status

--- a/pkg/config/configtypes.go
+++ b/pkg/config/configtypes.go
@@ -106,6 +106,7 @@ type ConfigFacilityTraining struct {
 	Discord            ConfigFacilityTrainingDiscord `json:"discord"`
 	Positions          []string                      `json:"positions"`
 	MaxRequestsPerUser int                           `json:"max_requests_per_user"`
+	SendToDiscord      bool                          `json:"send_to_discord"`
 }
 
 type ConfigFacilityTrainingDiscord struct {


### PR DESCRIPTION
training requests. ZDV doesn't need the Discord messages, just the database models. I think.